### PR TITLE
Updated async template code

### DIFF
--- a/google_analytics/templates/google_analytics/analytics_async_template.html
+++ b/google_analytics/templates/google_analytics/analytics_async_template.html
@@ -1,15 +1,11 @@
 <script type="text/javascript">
-(function() {
     var _gaq = _gaq || [];
     _gaq.push(['_setAccount', '{{ analytics_code }}']);
     _gaq.push(['_trackPageview']);
 
-    var ga=document.createElement('script');
-    ga.src=('https:'==document.location.protocol ? 
-        'https://ssl' : 'http://www')+'.google-analytics.com/ga.js';
-    ga.setAttribute('async','true');
-    // Avoid problems if the document doesn't actually contain a HEAD element:
-    var container = document.getElementsByTagName("head")[0] || document.body;
-    container.appendChild(ga);
-})();
+    (function() {
+        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+    })();
 </script>


### PR DESCRIPTION
Google changed their recommended JavaScript for the async method to insert the new script tag ahead of the first <script> in the document; I updated the template to match.
