### PR TITLE
Initial integration of the new page-load tracker

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -49,6 +49,13 @@ This is being added as an option rather than a replacement for two reasons:
    Adding the asynchronous tracking to existing code would cause backwards 
    incompatiblity.
 
+## Tracking Page-Load Time ##
+
+Google has added [page-load tracking](http://www.google.com/support/analyticshelp/bin/answer.py?hl=en&answer=1205784&topic=1120718).
+To use this feature add the following to your settings file:
+
+    GOOGLE_ANALYTICS_TRACK_PAGE_LOAD_TIME = True
+
 ## Supporting other tracking methods ##
 
 Sometimes, the built-in code snippets are not sufficient for what you want to

--- a/google_analytics/templates/google_analytics/analytics_async_template.html
+++ b/google_analytics/templates/google_analytics/analytics_async_template.html
@@ -3,6 +3,10 @@
     _gaq.push(['_setAccount', '{{ analytics_code }}']);
     _gaq.push(['_trackPageview']);
 
+    {% if track_page_load_time %}
+        _gaq.push(['_trackPageLoadTime']);
+    {% endif %}
+
     (function() {
         var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
         ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';

--- a/google_analytics/templates/google_analytics/analytics_template.html
+++ b/google_analytics/templates/google_analytics/analytics_template.html
@@ -6,4 +6,7 @@ document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.
 var pageTracker = _gat._getTracker("{{ analytics_code }}");
 pageTracker._initData();
 pageTracker._trackPageview();
+{% if track_page_load_time %}
+    pageTracker._trackPageLoadTime();
+{% endif %}
 </script>

--- a/google_analytics/templatetags/analytics.py
+++ b/google_analytics/templatetags/analytics.py
@@ -1,4 +1,5 @@
 from django import template
+from django.conf import settings
 from django.db import models
 from django.contrib.sites.models import Site
 
@@ -53,6 +54,9 @@ class AnalyticsNode(template.Node):
             t = loader.get_template(self.template_name)
             c = Context({
                 'analytics_code': code,
+                'track_page_load_time': getattr(settings,
+                                                "GOOGLE_ANALYTICS_TRACK_PAGE_LOAD_TIME",
+                                                False),
             })
             return t.render(c)
         else:


### PR DESCRIPTION
"Works on my test site" tested - feedback and wider testing welcome.

To avoid needing a model migration, this uses the meaningful but long
GOOGLE_ANALYTICS_TRACK_PAGE_LOAD_TIME setting to enable page-load tracking.
