### PR TITLE
Support for more complex templates

### DIFF
--- a/google_analytics/templatetags/analytics.py
+++ b/google_analytics/templatetags/analytics.py
@@ -62,8 +62,6 @@ class AnalyticsNode(template.Node):
             else:
                 d['analytics_code'] = code[0]
 
-            print d
-
             t = loader.get_template(self.template_name)
             c = Context(d)
 


### PR DESCRIPTION
Hi,

Thanks for you app, especially for building the feature of custom templates. It did some small changes to your code to support more complex templates. For example Piwik (http://www.piwik.org) an open source google analytics alternative, requires both the "site id" and the "host" argument, since there is no central piwik server. 

The changes I made allow users to use tags like the following
{% analytics "url example.com/piwik/ id 5" %}

which define the 'analytics_url' and 'analytics_id' template variable with the corresponding content of example.com/piwik/ and 5

The changes are backwards compatible, i.e. when the following tag is used
{% analytics "UX-111111" %}
the 'analytics_core' variable gets defined.

On these changes I built django-piwik-analytics application

https://github.com/glogiotatidis/django-piwik-analytics

Please consider merging these changes,
Giorgos
