### PR TITLE
allow GA code to come straight from settings.py

### DIFF
--- a/google_analytics/templatetags/analytics.py
+++ b/google_analytics/templatetags/analytics.py
@@ -22,7 +22,8 @@ def do_get_analytics(parser, token):
         raise template.TemplateSyntaxError, "%r cannot take more than one argument" % tag_name
    
     if not code:
-        current_site = Site.objects.get_current()
+        code = getattr(settings, 'GOOGLE_ANALYTICS_CODE', None)
+        current_site = None if code else Site.objects.get_current() 
     else:
         if not (code[0] == code[-1] and code[0] in ('"', "'")):
             raise template.TemplateSyntaxError, "%r tag's argument should be in quotes" % tag_name


### PR DESCRIPTION
There are uses cases (e.g. mine) where we may not want to have  a full-blown sites framework, or configurability from admin, but simply want to use an analytics code set in `settings.py`. This change allows that, preferring to use `settings.GOOGLE_ANALYTICS_CODE` when the code is not explicitly provided for the admin tag. When this isn't set, it falls back to the standard attempt to get the value from sites (not sure if this would be better the other way around, but this way works for me)
