### PR TITLE
Added settings key and removed need to use quoted template tag arguments

### DIFF
--- a/google_analytics/templatetags/analytics.py
+++ b/google_analytics/templatetags/analytics.py
@@ -20,23 +20,20 @@ def do_get_analytics(parser, token):
         code = None
     else:
         raise template.TemplateSyntaxError, "%r cannot take more than one argument" % tag_name
-   
+
     if not code:
         current_site = Site.objects.get_current()
     else:
-        if not (code[0] == code[-1] and code[0] in ('"', "'")):
-            raise template.TemplateSyntaxError, "%r tag's argument should be in quotes" % tag_name
-        code = code[1:-1]
         current_site = None
 
     return AnalyticsNode(current_site, code, template_name)
-    
+
 class AnalyticsNode(template.Node):
     def __init__(self, site=None, code=None, template_name='google_analytics/analytics_template.html'):
         self.site = site
         self.code = code
         self.template_name = template_name
-        
+
     def render(self, context):
         content = ''
         if self.site:
@@ -49,7 +46,7 @@ class AnalyticsNode(template.Node):
             code = self.code
         else:
             return ''
-        
+
         if code.strip() != '':
             t = loader.get_template(self.template_name)
             c = Context({
@@ -61,6 +58,6 @@ class AnalyticsNode(template.Node):
             return t.render(c)
         else:
             return ''
-        
+
 register.tag('analytics', do_get_analytics)
 register.tag('analytics_async', do_get_analytics)

--- a/google_analytics/templatetags/analytics.py
+++ b/google_analytics/templatetags/analytics.py
@@ -4,6 +4,7 @@ from django.db import models
 from django.contrib.sites.models import Site
 
 from django.template import Context, loader
+import re
 
 
 register = template.Library()
@@ -27,6 +28,7 @@ def do_get_analytics(parser, token):
     if not code:
         current_site = Site.objects.get_current()
     else:
+        code = re.sub(r'^["\']|["\']$', '', code)
         current_site = None
 
     return AnalyticsNode(current_site, code, template_name)

--- a/google_analytics/templatetags/analytics.py
+++ b/google_analytics/templatetags/analytics.py
@@ -21,6 +21,9 @@ def do_get_analytics(parser, token):
     else:
         raise template.TemplateSyntaxError, "%r cannot take more than one argument" % tag_name
 
+    if not code and settings.GOOGLE_ANALYTICS_KEY:
+        code = settings.GOOGLE_ANALYTICS_KEY
+
     if not code:
         current_site = Site.objects.get_current()
     else:


### PR DESCRIPTION
I modified this app in order to suit my needs, and thought I might as well share my modifications. They can be considered add-ons only, as the app stil retains all of its current functionality. I didn't want to put my GA account code in my template, so I thought I'd just supply the analytics template tag with a variable holding my key. That didn't work since the tag required input to be quoted in double quotes. I therefore ended up making the following to modifications to the app:
1. Quoting of the template tag input argument is no longer required. Instead leading/trailing quotes (single and double) are regexed away if present. 
2. If the settings key `GOOGLE_ANALYTICS_KEY` is present in your project its value will be used as code by the template tag if no code is supplied. At the moment this setting also takes precedence over the Sites-framework based solution (as that is what suited my needs).

This has the following implications (improvements if you ask me):
- `{% analytics %}` will return the code specified in `settings.GOOGLE_ANALYTICS_KEY` if present, and otherwise use the Sites framework.
- `{% analytics my_code %}` is now also an options (`my_code` being a template variable holding the code).
- `{% analytics "UA-123456-7" %}` still works fine, as does `{% analytics 'UA-123456-7' %}` and `{% analytics UA-123456-7 %}`.
